### PR TITLE
Feat: Flow (Part 1)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    warb (0.1.1)
+    warb (0.1.2)
       faraday (~> 2.13)
       faraday-multipart (~> 1.1)
 

--- a/docs/messages/flow.md
+++ b/docs/messages/flow.md
@@ -1,12 +1,248 @@
 # Flow
 
-Flow is a special type of message. We can summarize it simply as a form.
+Flow is a special type of interactive WhatsApp message that provides a "form-like" experience.
+With ```Warb.flow``` you can send static (navigate) or dynamic (data exchange) flows, both in draft and published modes.
 
-At this point of writing, this gem only supports sending existing flows, and it can only send flows which are in draft.
+Prerequisites (Meta)
+Business Account + Developer Account
+Verified Business to send flows in production WhatsApp (unverified accounts can only test in Meta’s Flow editor)
+For dynamic flows: endpoint + encryption configured in Meta (to handle user responses)
 
-To send flows, you can do as following:
+### Quick Examples
+
+##### Send a static draft flow:
 ```ruby
-Warb.flow.dispatch(recipient_number, flow_id: "flow_id", screen: "screen")
+Warb.flow.dispatch(recipient_number, flow_id: "0000000000000000", mode: "draft", screen: "INITIAL", body: "Open flow")
 ```
 
-`flow_id` must be the ID of the flow and `screen` must be the ID of the first screen of the flow.
+##### Send a dynamic draft flow:
+```ruby
+Warb.flow.dispatch(recipient_number,
+  flow_id:     "0000000000000000",
+  mode:        "draft",
+  flow_action: "data_exchange",
+  body:        "Open flow"
+)
+```
+
+##### Send a dynamic published flow with custom header, body, and footer:
+```ruby
+Warb.flow.dispatch(recipient_number) do |flow|
+  flow.flow_id     = "0000000000000000"
+  flow.flow_action = "data_exchange"
+  flow.mode        = "published"
+  flow.body        = "Hello! Please follow the instructions."
+  flow.footer      = "Need help? Reply to this message."
+
+  flow.header = {
+    type: "document",
+    document: {
+      link:     "https://example.com/contract.pdf",
+      filename: "contract.pdf"
+    }
+  }
+
+  flow.flow_cta = "Sign"
+end
+```
+
+### Dispatching Flow Messages
+```ruby
+Warb.flow.dispatch(recipient_number, **params, &block)
+```
+##### Parameters
+| Attribute     | Type     | Required                           | Description                                                 |
+| ------------- | -------- | ---------------------------------- | ----------------------------------------------------------- |
+| `flow_id`     | `String` | Yes                                | The ID of the Flow created in Meta.                         |
+| `body`        | `String` | Yes                                | Body text shown in the Flow message.                        |
+| `flow_action` | `String` | No                                 | `"navigate"` (default) or `"data_exchange"`.                |
+| `mode`        | `String` | Yes if `flow mode == 'draft'`      | `"published"` (default) or `"draft"`.                       |
+| `screen`      | `String` | Yes if `flow_action == "navigate"` | Initial screen to navigate to.                              |
+| `flow_cta`    | `String` | No                                 | Label for the button that opens the Flow.                   |
+| `flow_token`  | `String` | No                                 | Token for dynamic flows (encryption/validation).            |
+| `data`        | `Hash`   | No                                 | Prefill data for navigate flows.                            |
+| `header`      | `Hash`   | No                                 | Optional header (see below).                                |
+| `footer`      | `String` | No                                 | Optional footer text.                                       |
+
+### Supported Headers
+
+You must provide exactly one of the following header types:
+
+##### Text
+```ruby
+{ type: "text", text: "Flow title" }
+```
+
+##### Image
+```ruby
+{ type: "image", image: { id: "MEDIA_ID" } }
+# or
+{ type: "image", image: { link: "https://example.com/img.jpg" } }
+```
+
+##### Video
+```ruby
+{ type: "video", video: { id: "MEDIA_ID" } }
+# or
+{ type: "video", video: { link: "https://example.com/video.mp4" } }
+```
+
+##### Document
+```ruby
+{ type: "document", document: { id: "MEDIA_ID" } }
+# or
+{ type: "document", document: { link: "https://example.com/file.pdf", filename: "file.pdf" } }
+```
+
+##### Note:
+
+id must be obtained from a media upload (Warb.image/video/document.upload).
+
+link must be a public URL. For documents, filename is required to determine preview capabilities.
+
+### Modes and Actions
+##### mode
+
+"published" (default): Published flow. Allows customizing header, body, footer, and flow_cta.
+
+"draft": Draft flow. Usable via Meta Flow editor and sometimes on WhatsApp, but some elements (like body text and CTA) may be restricted.
+
+##### flow_action
+
+"navigate" (default) → static flow
+Requires screen, can include initial data:
+```ruby
+Warb.flow.dispatch(recipient_number,
+  flow_id: "0000000000000000",
+  screen:  "INITIAL",
+  body:    "Continue",
+  data:    { prefill: { name: "Alice", email: "alice@example.com" } }
+)
+```
+
+"data_exchange" → dynamic flow
+No flow_action_payload (omitted automatically):
+```ruby
+Warb.flow.dispatch(recipient_number,
+  flow_id:     "0000000000000000",
+  flow_action: "data_exchange",
+  body:        "Fill the form",
+)
+```
+
+### Block Building
+
+You can also build flows using a block:
+```ruby
+Warb.flow.dispatch(recipient_number) do |flow|
+  flow.flow_id     = "0000000000000000"
+  flow.flow_action = "data_exchange"
+  flow.mode        = "published"
+  flow.body        = "We need some information"
+
+  flow.header = { type: "text", text: "Registration" }
+  flow.footer = "Thanks!"
+
+  flow.flow_cta   = "Open"
+end
+```
+
+### Validations
+
+Before sending, the gem enforces:
+
+flow_id is required → raises ArgumentError: flow_id is required
+
+body is required → raises ArgumentError: body is required for flow message
+
+If flow_action == "navigate" then screen is required →
+raises ArgumentError: screen is required for flow_action=navigate
+
+The Meta API may return additional errors (invalid parameters, missing fields, etc.), which are raised as Warb::BadRequest, Warb::RequestError, etc.
+
+Example Scenarios
+1) Static / Draft
+```ruby
+Warb.flow.dispatch(recipient_number,
+  flow_id: "0000000000000000",
+  screen:  "INITIAL",
+  mode:    "draft",
+  body:    "Open flow"
+)
+```
+
+2) Dynamic / Draft
+```ruby
+Warb.flow.dispatch(recipient_number,
+  flow_id:     "0000000000000000",
+  flow_action: "data_exchange",
+  mode:        "draft",
+  body:        "Fill the form"
+)
+```
+
+3) Dynamic / Published with Document Header
+```ruby
+Warb.flow.dispatch(recipient_number) do |flow|
+  flow.flow_id     = "0000000000000000"
+  flow.flow_action = "data_exchange"
+  flow.mode        = "published"
+  flow.body        = "Please review and sign the document."
+  flow.footer      = "Reply if you need assistance."
+  flow.flow_cta    = "Sign"
+
+  flow.header = {
+    type: "document",
+    document: {
+      link:     "https://www.thecampusqdl.com/uploads/files/pdf_sample_2.pdf",
+      filename: "pdf_sample_2.pdf"
+    }
+  }
+end
+```
+
+4) Static / Published with Image Header (id) and Prefill Data
+```ruby
+image_id = Warb.image.upload(file_path: "banner.jpg", file_type: "image/jpeg")
+
+Warb.flow.dispatch(recipient_number) do |flow|
+  flow.flow_id = "0000000000000000"
+  flow.mode    = "published"
+  flow.body    = "Open and check your data"
+
+  flow.header = { type: "image", image: { id: image_id } }
+
+  flow.screen = "INITIAL"
+  flow.data   = { prefill: { name: "John", email: "john@example.com" } }
+end
+```
+
+### Generated Payload (Reference)
+
+Example payload produced by the gem:
+```ruby
+{
+  "type": "interactive",
+  "interactive": {
+    "type": "flow",
+    "header": { ... },
+    "body": { "text": "..." },
+    "footer": { "text": "..." },
+    "action": {
+      "name": "flow",
+      "parameters": {
+        "flow_message_version": "3",
+        "flow_id": "....",
+        "flow_action": "navigate" | "data_exchange",
+        "mode": "published" | "draft",
+        "flow_cta": "Open",
+        "flow_token": "TOKEN",
+        "flow_action_payload": {
+          "screen": "INITIAL",
+          "data": { "prefill": { ... } }
+        }
+      }
+    }
+  }
+}
+```

--- a/lib/warb.rb
+++ b/lib/warb.rb
@@ -16,6 +16,7 @@ require_relative 'warb/response_error_handler'
 require_relative 'warb/response'
 
 # Resources
+require_relative 'warb/resources/helpers/header'
 require_relative 'warb/resources/resource'
 require_relative 'warb/resources/text'
 require_relative 'warb/resources/image'

--- a/lib/warb.rb
+++ b/lib/warb.rb
@@ -16,6 +16,7 @@ require_relative 'warb/response_error_handler'
 require_relative 'warb/response'
 
 # Resources
+require_relative 'warb/resources/validation'
 require_relative 'warb/resources/helpers/header'
 require_relative 'warb/resources/resource'
 require_relative 'warb/resources/text'

--- a/lib/warb/resources/flow.rb
+++ b/lib/warb/resources/flow.rb
@@ -3,34 +3,87 @@
 module Warb
   module Resources
     class Flow < Resource
-      attr_accessor :flow_id, :screen
+      attr_accessor :flow_id, :screen, :flow_action, :mode,
+                    :flow_cta, :flow_token, :body, :header, :footer, :data
 
-      # rubocop:disable Metrics/MethodLength
       def build_payload
+        validate!
+
         {
-          type: 'interactive',
-          interactive: {
-            type: 'flow',
-            body: {
-              text: 'Not shown in draft mode'
-            },
-            action: {
-              name: 'flow',
-              parameters: {
-                flow_message_version: '3',
-                flow_action: 'navigate',
-                flow_id: flow_id || @params[:flow_id],
-                flow_cta: 'Not shown in draft mode',
-                mode: 'draft',
-                flow_action_payload: {
-                  screen: screen || @params[:screen]
-                }
-              }
-            }
-          }
+          type: "interactive",
+          interactive: build_interactive
         }
       end
-      # rubocop:enable Metrics/MethodLength
+
+      private
+
+      def build_interactive
+        interactive = {
+          type: "flow",
+          action: {
+            name: "flow",
+            parameters: build_action_parameters
+          }
+        }
+
+        header = resolve(:header)
+        interactive[:header] = header if header.is_a?(Hash)
+
+        body = resolve(:body)
+        interactive[:body] = { text: body }
+
+        footer = resolve(:footer)
+        interactive[:footer] = { text: footer } unless blank?(footer)
+
+        interactive
+      end
+
+      def build_action_parameters
+        action = resolve(:flow_action, "navigate").to_s
+        mode    = resolve(:mode, "published").to_s
+
+        params = {
+          flow_message_version: "3",
+          flow_id: resolve(:flow_id),
+          flow_action: action,
+          mode: mode
+        }
+
+        label = resolve(:flow_cta)
+        params[:flow_cta] = label unless blank?(label)
+
+        token = resolve(:flow_token)
+        params[:flow_token] = token unless blank?(token)
+
+        if action == "navigate"
+          payload = { screen: resolve(:screen) }
+          initial = resolve(:data)
+          payload[:data] = initial unless blank?(initial)
+          params[:flow_action_payload] = payload
+        end
+
+        params
+      end
+
+      def validate!
+        raise ArgumentError, "flow_id is required" if blank?(resolve(:flow_id))
+        raise ArgumentError, "body is required for flow message" if blank?(resolve(:body))
+
+        if resolve(:flow_action, "navigate").to_s == "navigate" && blank?(resolve(:screen))
+          raise ArgumentError, "screen is required for flow_action=navigate"
+        end
+      end
+
+      def resolve(name, default = nil)
+        val = send(name)
+        val = @params[name] if blank?(val) && @params&.key?(name)
+        val = default if blank?(val) && !default.nil?
+        val
+      end
+
+      def blank?(val)
+        val.respond_to?(:empty?) ? val.empty? : !val
+      end
     end
   end
 end

--- a/lib/warb/resources/flow.rb
+++ b/lib/warb/resources/flow.rb
@@ -66,23 +66,12 @@ module Warb
       end
 
       def validate!
-        raise ArgumentError, 'flow_id is required' if blank?(resolve(:flow_id))
-        raise ArgumentError, 'body is required for flow message' if blank?(resolve(:body))
+        validates :flow_id, required: true
+        validates :body,    required: true
 
-        return unless resolve(:flow_action, 'navigate').to_s == 'navigate' && blank?(resolve(:screen))
-
-        raise ArgumentError, 'screen is required for flow_action=navigate'
-      end
-
-      def resolve(name, default = nil)
-        val = send(name)
-        val = @params[name] if blank?(val) && @params&.key?(name)
-        val = default if blank?(val) && !default.nil?
-        val
-      end
-
-      def blank?(val)
-        val.respond_to?(:empty?) ? val.empty? : !val
+        validates :screen,
+                 required: -> { resolve(:flow_action, 'navigate').to_s == 'navigate' },
+                 message:  'screen is required for flow_action=navigate'
       end
     end
   end

--- a/lib/warb/resources/flow.rb
+++ b/lib/warb/resources/flow.rb
@@ -4,7 +4,8 @@ module Warb
   module Resources
     class Flow < Resource
       attr_accessor :flow_id, :screen, :flow_action, :mode,
-                    :flow_cta, :flow_token, :body, :header, :footer, :data
+                    :flow_cta, :flow_token, :body, :header, :footer, :data,
+                    :draft, :data_exchange
 
       def build_payload
         validate!
@@ -39,14 +40,11 @@ module Warb
       end
 
       def build_action_parameters
-        action = resolve(:flow_action, 'navigate').to_s
-        mode = resolve(:mode, 'published').to_s
-
         params = {
           flow_message_version: '3',
           flow_id: resolve(:flow_id),
-          flow_action: action,
-          mode: mode
+          flow_action: final_action,
+          mode: final_mode
         }
 
         resolve(:flow_cta)
@@ -55,7 +53,7 @@ module Warb
         resolve(:flow_token)
           .then { |token| params[:flow_token] = token unless blank?(token) }
 
-        if action == 'navigate'
+        if final_action == 'navigate'
           payload = { screen: resolve(:screen) }
           initial = resolve(:data)
           payload[:data] = initial unless blank?(initial)
@@ -65,12 +63,24 @@ module Warb
         params
       end
 
+      def final_action
+        explicit = raw_value(:flow_action)
+        return explicit.to_s unless blank?(explicit)
+        resolve(:data_exchange) ? 'data_exchange' : 'navigate'
+      end
+
+      def final_mode
+        explicit = raw_value(:mode)
+        return explicit.to_s unless blank?(explicit)
+        resolve(:draft) ? 'draft' : 'published'
+      end
+
       def validate!
         validates :flow_id, required: true
         validates :body,    required: true
 
         validates :screen,
-                 required: -> { resolve(:flow_action, 'navigate').to_s == 'navigate' },
+                 required: -> { final_action == 'navigate' },
                  message:  'screen is required for flow_action=navigate'
       end
     end

--- a/lib/warb/resources/flow.rb
+++ b/lib/warb/resources/flow.rb
@@ -3,6 +3,8 @@
 module Warb
   module Resources
     class Flow < Resource
+      include Helpers::Header
+
       attr_accessor :flow_id, :screen, :flow_action, :mode,
                     :flow_cta, :flow_token, :body, :header, :footer, :data,
                     :draft, :data_exchange
@@ -27,8 +29,12 @@ module Warb
           }
         }
 
-        resolve(:header)
-          .then { |header| interactive[:header] = header if header.is_a?(Hash) }
+        header = resolve(:header)
+        if header.is_a?(Hash)
+          interactive[:header] = header
+        elsif header.respond_to?(:build_header)
+          interactive[:header] = header.build_header
+        end
 
         resolve(:body)
           .then { |body| interactive[:body] = { text: body } }

--- a/lib/warb/resources/flow.rb
+++ b/lib/warb/resources/flow.rb
@@ -26,14 +26,14 @@ module Warb
           }
         }
 
-        header = resolve(:header)
-        interactive[:header] = header if header.is_a?(Hash)
+        resolve(:header)
+          .then { |header| interactive[:header] = header if header.is_a?(Hash) }
 
-        body = resolve(:body)
-        interactive[:body] = { text: body }
+        resolve(:body)
+          .then { |body| interactive[:body] = { text: body } }
 
-        footer = resolve(:footer)
-        interactive[:footer] = { text: footer } unless blank?(footer)
+        resolve(:footer)
+          .then { |footer| interactive[:footer] = { text: footer } unless blank?(footer) }
 
         interactive
       end
@@ -49,11 +49,11 @@ module Warb
           mode: mode
         }
 
-        label = resolve(:flow_cta)
-        params[:flow_cta] = label unless blank?(label)
+        resolve(:flow_cta)
+          .then { |label| params[:flow_cta] = label unless blank?(label) }
 
-        token = resolve(:flow_token)
-        params[:flow_token] = token unless blank?(token)
+        resolve(:flow_token)
+          .then { |token| params[:flow_token] = token unless blank?(token) }
 
         if action == 'navigate'
           payload = { screen: resolve(:screen) }

--- a/lib/warb/resources/flow.rb
+++ b/lib/warb/resources/flow.rb
@@ -10,7 +10,7 @@ module Warb
         validate!
 
         {
-          type: "interactive",
+          type: 'interactive',
           interactive: build_interactive
         }
       end
@@ -19,9 +19,9 @@ module Warb
 
       def build_interactive
         interactive = {
-          type: "flow",
+          type: 'flow',
           action: {
-            name: "flow",
+            name: 'flow',
             parameters: build_action_parameters
           }
         }
@@ -39,11 +39,11 @@ module Warb
       end
 
       def build_action_parameters
-        action = resolve(:flow_action, "navigate").to_s
-        mode    = resolve(:mode, "published").to_s
+        action = resolve(:flow_action, 'navigate').to_s
+        mode = resolve(:mode, 'published').to_s
 
         params = {
-          flow_message_version: "3",
+          flow_message_version: '3',
           flow_id: resolve(:flow_id),
           flow_action: action,
           mode: mode
@@ -55,7 +55,7 @@ module Warb
         token = resolve(:flow_token)
         params[:flow_token] = token unless blank?(token)
 
-        if action == "navigate"
+        if action == 'navigate'
           payload = { screen: resolve(:screen) }
           initial = resolve(:data)
           payload[:data] = initial unless blank?(initial)
@@ -66,12 +66,12 @@ module Warb
       end
 
       def validate!
-        raise ArgumentError, "flow_id is required" if blank?(resolve(:flow_id))
-        raise ArgumentError, "body is required for flow message" if blank?(resolve(:body))
+        raise ArgumentError, 'flow_id is required' if blank?(resolve(:flow_id))
+        raise ArgumentError, 'body is required for flow message' if blank?(resolve(:body))
 
-        if resolve(:flow_action, "navigate").to_s == "navigate" && blank?(resolve(:screen))
-          raise ArgumentError, "screen is required for flow_action=navigate"
-        end
+        return unless resolve(:flow_action, 'navigate').to_s == 'navigate' && blank?(resolve(:screen))
+
+        raise ArgumentError, 'screen is required for flow_action=navigate'
       end
 
       def resolve(name, default = nil)

--- a/lib/warb/resources/helpers/header.rb
+++ b/lib/warb/resources/helpers/header.rb
@@ -1,0 +1,35 @@
+module Warb
+  module Resources
+    module Helpers
+      module Header
+        def add_text_header(content: nil, message: nil, text: nil, parameter_name: nil, &block)
+          add_header(Warb::Resources::Text.new(content:, message:, text:, parameter_name:), &block)
+        end
+
+        def add_image_header(media_id: nil, link: nil, &block)
+          add_header(Warb::Resources::Image.new(media_id:, link:), &block)
+        end
+
+        def add_document_header(media_id: nil, link: nil, filename: nil, &block)
+          add_header(Warb::Resources::Document.new(media_id:, link:, filename:), &block)
+        end
+
+        def add_video_header(media_id: nil, link: nil, &block)
+          add_header(Warb::Resources::Video.new(media_id:, link:), &block)
+        end
+
+        def add_location_header(latitude: nil, longitude: nil, address: nil, name: nil, &block)
+          add_header(Warb::Resources::Location.new(latitude:, longitude:, address:, name:), &block)
+        end
+
+        private
+
+        def add_header(instance, &)
+          @header = instance
+
+          block_given? ? @header.tap(&) : @header
+        end
+      end
+    end
+  end
+end

--- a/lib/warb/resources/resource.rb
+++ b/lib/warb/resources/resource.rb
@@ -3,6 +3,8 @@
 module Warb
   module Resources
     class Resource
+      include Validation
+
       def initialize(**params)
         @params = params
       end

--- a/lib/warb/resources/template.rb
+++ b/lib/warb/resources/template.rb
@@ -3,6 +3,8 @@
 module Warb
   module Resources
     class Template < Resource
+      include Helpers::Header
+
       attr_accessor :name, :language, :resources, :header, :category, :body, :buttons
 
       def initialize(**params)
@@ -58,26 +60,6 @@ module Warb
         add_parameter(parameter_name, Text.new(**params), &)
       end
 
-      def add_text_header(content: nil, message: nil, text: nil, parameter_name: nil, &block)
-        add_header(Text.new(content:, message:, text:, parameter_name:), &block)
-      end
-
-      def add_image_header(media_id: nil, link: nil, &block)
-        add_header(Image.new(media_id:, link:), &block)
-      end
-
-      def add_document_header(media_id: nil, link: nil, filename: nil, &block)
-        add_header(Document.new(media_id:, link:, filename:), &block)
-      end
-
-      def add_video_header(media_id: nil, link: nil, &block)
-        add_header(Video.new(media_id:, link:), &block)
-      end
-
-      def add_location_header(latitude: nil, longitude: nil, address: nil, name: nil, &block)
-        add_header(Location.new(latitude:, longitude:, address:, name:), &block)
-      end
-
       def add_quick_reply_button(index: position, &block)
         add_button(Warb::Components::QuickReplyButton.new(index:), &block)
       end
@@ -103,12 +85,6 @@ module Warb
       end
 
       private
-
-      def add_header(instance, &)
-        @header = instance
-
-        block_given? ? @header.tap(&) : @header
-      end
 
       def component_header
         return unless header.is_a? Resource

--- a/lib/warb/resources/validation.rb
+++ b/lib/warb/resources/validation.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Warb
+  module Resources
+    module Validation
+      def blank?(val)
+        val.respond_to?(:empty?) ? val.empty? : !val
+      end
+
+      def resolve(field, default = nil)
+        val = respond_to?(field) ? public_send(field) : nil
+        val = @params[field] if blank?(val) && defined?(@params) && @params&.key?(field)
+        val = default if blank?(val) && !default.nil?
+        val
+      end
+
+      def validates(field, required: false, message: nil)
+        needed = required.respond_to?(:call) ? required.call : required
+        return unless needed
+        return unless blank?(resolve(field))
+
+        raise ArgumentError, (message || "#{field} is required")
+      end
+    end
+  end
+end

--- a/lib/warb/resources/validation.rb
+++ b/lib/warb/resources/validation.rb
@@ -7,8 +7,12 @@ module Warb
         val.respond_to?(:empty?) ? val.empty? : !val
       end
 
+      def raw_value(field)
+        respond_to?(field) ? public_send(field) : nil
+      end
+
       def resolve(field, default = nil)
-        val = respond_to?(field) ? public_send(field) : nil
+        val = raw_value(field)
         val = @params[field] if blank?(val) && defined?(@params) && @params&.key?(field)
         val = default if blank?(val) && !default.nil?
         val

--- a/spec/factories/resources/flows.rb
+++ b/spec/factories/resources/flows.rb
@@ -3,6 +3,57 @@
 FactoryBot.define do
   factory :flow, class: Warb::Resources::Flow do
     flow_id { Faker::Number.numerify '#######' }
-    screen { Faker::App.name }
+    screen  { Faker::App.name }
+    body    { Faker::Lorem.sentence }
+
+    trait :dynamic do
+      flow_action { 'data_exchange' }
+    end
+
+    trait :with_initial_data do
+      data do
+        {
+          prefill: {
+            name:  Faker::Name.name,
+            email: Faker::Internet.email
+          }
+        }
+      end
+    end
+
+    trait :with_header do
+      transient do
+        header_type { %i[text image video document].sample }
+        use_id      { [true, false].sample }
+      end
+
+      header do
+        case header_type
+        when :text
+          { type: "text", text: Faker::Lorem.sentence }
+
+        when :image
+          media = use_id ? { id: Faker::Number.number(digits: 16).to_s } : { link: Faker::Internet.url }
+          { type: "image", image: media }
+
+        when :video
+          media = use_id ? { id: Faker::Number.number(digits: 16).to_s } : { link: Faker::Internet.url }
+          { type: "video", video: media }
+
+        when :document
+          if use_id
+            { type: "document", document: { id: Faker::Number.number(digits: 16).to_s } }
+          else
+            filename = "doc_#{SecureRandom.hex(4)}.pdf"
+            { type: "document", document: { link: Faker::Internet.url, filename: filename } }
+          end
+        end
+      end
+    end
+
+    trait :complete_structure do
+      with_header
+      footer { Faker::Lorem.sentence }
+    end
   end
 end

--- a/spec/factories/resources/flows.rb
+++ b/spec/factories/resources/flows.rb
@@ -23,25 +23,33 @@ FactoryBot.define do
         use_id      { [true, false].sample }
       end
 
-      header do
-        case header_type
+      after(:build) do |flow, evaluator|
+        case evaluator.header_type
         when :text
-          { type: 'text', text: Faker::Lorem.sentence }
+          flow.add_text_header(text: Faker::Lorem.sentence)
 
         when :image
-          media = use_id ? { id: Faker::Number.number(digits: 16).to_s } : { link: Faker::Internet.url }
-          { type: 'image', image: media }
+          if evaluator.use_id
+            flow.add_image_header(media_id: Faker::Number.number(digits: 16).to_s)
+          else
+            flow.add_image_header(link: Faker::Internet.url)
+          end
 
         when :video
-          media = use_id ? { id: Faker::Number.number(digits: 16).to_s } : { link: Faker::Internet.url }
-          { type: 'video', video: media }
+          if evaluator.use_id
+            flow.add_video_header(media_id: Faker::Number.number(digits: 16).to_s)
+          else
+            flow.add_video_header(link: Faker::Internet.url)
+          end
 
         when :document
-          if use_id
-            { type: 'document', document: { id: Faker::Number.number(digits: 16).to_s } }
+          if evaluator.use_id
+            flow.add_document_header(media_id: Faker::Number.number(digits: 16).to_s, filename: nil)
           else
-            filename = "doc_#{SecureRandom.hex(4)}.pdf"
-            { type: 'document', document: { link: Faker::Internet.url, filename: filename } }
+            flow.add_document_header(
+              link: Faker::Internet.url,
+              filename: "doc_#{SecureRandom.hex(4)}.pdf"
+            )
           end
         end
       end

--- a/spec/factories/resources/flows.rb
+++ b/spec/factories/resources/flows.rb
@@ -54,6 +54,8 @@ FactoryBot.define do
     trait :complete_structure do
       with_header
       footer { Faker::Lorem.sentence }
+      flow_cta { Faker::Lorem.word }
+      flow_token { Faker::Alphanumeric.alphanumeric }
     end
   end
 end

--- a/spec/factories/resources/flows.rb
+++ b/spec/factories/resources/flows.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
       data do
         {
           prefill: {
-            name:  Faker::Name.name,
+            name: Faker::Name.name,
             email: Faker::Internet.email
           }
         }
@@ -30,22 +30,22 @@ FactoryBot.define do
       header do
         case header_type
         when :text
-          { type: "text", text: Faker::Lorem.sentence }
+          { type: 'text', text: Faker::Lorem.sentence }
 
         when :image
           media = use_id ? { id: Faker::Number.number(digits: 16).to_s } : { link: Faker::Internet.url }
-          { type: "image", image: media }
+          { type: 'image', image: media }
 
         when :video
           media = use_id ? { id: Faker::Number.number(digits: 16).to_s } : { link: Faker::Internet.url }
-          { type: "video", video: media }
+          { type: 'video', video: media }
 
         when :document
           if use_id
-            { type: "document", document: { id: Faker::Number.number(digits: 16).to_s } }
+            { type: 'document', document: { id: Faker::Number.number(digits: 16).to_s } }
           else
             filename = "doc_#{SecureRandom.hex(4)}.pdf"
-            { type: "document", document: { link: Faker::Internet.url, filename: filename } }
+            { type: 'document', document: { link: Faker::Internet.url, filename: filename } }
           end
         end
       end

--- a/spec/factories/resources/flows.rb
+++ b/spec/factories/resources/flows.rb
@@ -6,10 +6,6 @@ FactoryBot.define do
     screen  { Faker::App.name }
     body    { Faker::Lorem.sentence }
 
-    trait :dynamic do
-      flow_action { 'data_exchange' }
-    end
-
     trait :with_initial_data do
       data do
         {

--- a/spec/warb/resources/flow_spec.rb
+++ b/spec/warb/resources/flow_spec.rb
@@ -1,12 +1,106 @@
 # frozen_string_literal: true
+require 'byebug'
 
-RSpec.describe Warb::Resources::Contact do
+RSpec.describe Warb::Resources::Flow do
+
+  let(:flow_resource) { build :flow }
+
   describe '#build_payload' do
-    subject { build(:flow).build_payload }
+    context 'complete structure' do
+      let(:flow_resource) { build :flow, :complete_structure }
+      subject { flow_resource.build_payload }
 
-    it 'validate content' do
-      expect(subject).to have_key(:type)
-      expect(subject).to have_key(:interactive)
+      it 'with correct types of data' do
+        expect(subject).to include(:type, :interactive)
+        expect(subject[:type]).to eq('interactive')
+
+        interactive = subject[:interactive]
+        expect(interactive[:type]).to eq('flow')
+        expect(interactive[:action]).to be_a(Hash)
+        expect(interactive[:action][:name]).to eq('flow')
+
+        header = interactive[:header]
+        case header[:type]
+          when "text" then expect(header[:text]).to be_a(String)
+          when "image" then expect(header[:image]).to include(:id).or include(:link)
+          when "video" then expect(header[:video]).to include(:id).or include(:link)
+          when "document" then expect(header[:document]).to include(:id).or include(:link)
+        end
+        expect(interactive[:body][:text]).to be_a(String)
+        expect(interactive[:footer][:text]).to be_a(String)
+      end
+    end
+
+    context 'with optional fields' do
+      subject { flow_resource.build_payload }
+
+      it 'omits header/footer when blank' do
+        expect(subject[:interactive]).not_to have_key(:header)
+        expect(subject[:interactive]).not_to have_key(:footer)
+      end
+    end
+
+    context 'with necessary values' do
+      subject { flow_resource.build_payload }
+
+      it 'and default parameters' do
+        params = subject[:interactive][:action][:parameters]
+        expect(params[:flow_message_version]).to eq('3')
+        expect(params[:flow_id]).to be_a(String)
+        expect(params[:flow_action]).to eq('navigate')
+        expect(params[:mode]).to eq('published')
+        expect(params[:flow_action_payload][:screen]).to be_a(String)
+      end
+
+      let(:flow_resource) { build :flow, :with_initial_data }
+
+      it 'and initial data' do
+        payload = subject[:interactive][:action][:parameters][:flow_action_payload]
+
+        expect(payload[:data][:prefill][:name]).to be_a(String)
+        expect(payload[:data][:prefill][:email]).to be_a(String)
+      end
+    end
+
+    context 'dynamic flow' do
+      let(:flow_resource) { build :flow, :dynamic }
+      subject { flow_resource.build_payload }
+
+      it 'does not include flow_action_payload with screen or data' do
+        payload = subject[:interactive][:action][:parameters]
+        expect(payload[:flow_action]).to eq('data_exchange')
+        expect(payload).not_to have_key(:flow_action_payload)
+      end
+    end
+
+    context 'validation' do
+      it 'raises when flow_id is missing' do
+        resource = build(:flow, flow_id: nil)
+        expect { resource.build_payload }.to raise_error(ArgumentError, /flow_id is required/)
+      end
+
+      it 'raises when action=navigate and screen is missing' do
+        resource = build(:flow, screen: nil)
+        expect { resource.build_payload }.to raise_error(ArgumentError, /screen is required/)
+      end
+
+      it 'does not raise when action=data_exchange without screen' do
+        resource = build(:flow, body: nil)
+        expect { resource.build_payload }.to raise_error(ArgumentError, /body is required/)
+      end
+    end
+
+    context 'attribute precedence (instance ivars over params hash over defaults)' do
+      subject { flow_resource.build_payload }
+
+      it 'prefers explicit ivars over constructor params' do
+        flow_resource.flow_id = 'FROM_IVAR'
+        flow_resource.screen  = 'FROM_IVAR'
+
+        params = subject[:interactive][:action][:parameters]
+        expect(params[:flow_id]).to eq('FROM_IVAR')
+        expect(params[:flow_action_payload][:screen]).to eq('FROM_IVAR')
+      end
     end
   end
 end

--- a/spec/warb/resources/flow_spec.rb
+++ b/spec/warb/resources/flow_spec.rb
@@ -27,15 +27,19 @@ RSpec.describe Warb::Resources::Flow do
         end
         expect(interactive[:body][:text]).to be_a(String)
         expect(interactive[:footer][:text]).to be_a(String)
+        expect(interactive[:action][:parameters][:flow_cta]).to be_a(String)
+        expect(interactive[:action][:parameters][:flow_token]).to be_a(String)
       end
     end
 
-    context 'with optional fields' do
+    context 'when optional fields are blank' do
       subject { flow_resource.build_payload }
 
-      it 'omits header/footer when blank' do
+      it 'omits the fields' do
         expect(subject[:interactive]).not_to have_key(:header)
         expect(subject[:interactive]).not_to have_key(:footer)
+        expect(subject[:interactive][:action][:parameters]).not_to have_key(:footer)
+        expect(subject[:interactive][:action][:parameters]).not_to have_key(:footer)
       end
     end
 

--- a/spec/warb/resources/flow_spec.rb
+++ b/spec/warb/resources/flow_spec.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
-require 'byebug'
 
 RSpec.describe Warb::Resources::Flow do
-
   let(:flow_resource) { build :flow }
 
   describe '#build_payload' do
     context 'complete structure' do
-      let(:flow_resource) { build :flow, :complete_structure }
       subject { flow_resource.build_payload }
+
+      let(:flow_resource) { build :flow, :complete_structure }
 
       it 'with correct types of data' do
         expect(subject).to include(:type, :interactive)
@@ -21,10 +20,10 @@ RSpec.describe Warb::Resources::Flow do
 
         header = interactive[:header]
         case header[:type]
-          when "text" then expect(header[:text]).to be_a(String)
-          when "image" then expect(header[:image]).to include(:id).or include(:link)
-          when "video" then expect(header[:video]).to include(:id).or include(:link)
-          when "document" then expect(header[:document]).to include(:id).or include(:link)
+        when 'text' then expect(header[:text]).to be_a(String)
+        when 'image' then expect(header[:image]).to include(:id).or include(:link)
+        when 'video' then expect(header[:video]).to include(:id).or include(:link)
+        when 'document' then expect(header[:document]).to include(:id).or include(:link)
         end
         expect(interactive[:body][:text]).to be_a(String)
         expect(interactive[:footer][:text]).to be_a(String)
@@ -43,6 +42,8 @@ RSpec.describe Warb::Resources::Flow do
     context 'with necessary values' do
       subject { flow_resource.build_payload }
 
+      let(:flow_resource) { build :flow, :with_initial_data }
+
       it 'and default parameters' do
         params = subject[:interactive][:action][:parameters]
         expect(params[:flow_message_version]).to eq('3')
@@ -51,8 +52,6 @@ RSpec.describe Warb::Resources::Flow do
         expect(params[:mode]).to eq('published')
         expect(params[:flow_action_payload][:screen]).to be_a(String)
       end
-
-      let(:flow_resource) { build :flow, :with_initial_data }
 
       it 'and initial data' do
         payload = subject[:interactive][:action][:parameters][:flow_action_payload]
@@ -63,8 +62,9 @@ RSpec.describe Warb::Resources::Flow do
     end
 
     context 'dynamic flow' do
-      let(:flow_resource) { build :flow, :dynamic }
       subject { flow_resource.build_payload }
+
+      let(:flow_resource) { build :flow, :dynamic }
 
       it 'does not include flow_action_payload with screen or data' do
         payload = subject[:interactive][:action][:parameters]

--- a/spec/warb/resources/flow_spec.rb
+++ b/spec/warb/resources/flow_spec.rb
@@ -120,4 +120,114 @@ RSpec.describe Warb::Resources::Flow do
       end
     end
   end
+
+  describe 'headers via helpers (factory)' do
+    context 'text header' do
+      it 'embeds text header' do
+        flow = build(:flow)
+        flow.add_text_header(text: 'Hello!')
+        header = flow.build_payload[:interactive][:header]
+
+        expect(header[:type]).to eq('text')
+        expect(header[:text]).to eq('Hello!')
+      end
+    end
+
+    context 'image header' do
+      it 'with id' do
+        flow = build(:flow)
+        flow.add_image_header(media_id: 'IMG123')
+
+        header = flow.build_payload[:interactive][:header]
+        expect(header[:type]).to eq('image')
+        expect(header[:image][:id]).to eq('IMG123')
+        expect(header[:image][:link]).to be_nil
+      end
+
+      it 'with link' do
+        flow = build(:flow)
+        link = 'https://example.com/img.jpg'
+        flow.add_image_header(link:)
+
+        header = flow.build_payload[:interactive][:header]
+        expect(header[:type]).to eq('image')
+        expect(header[:image][:link]).to eq(link)
+        expect(header[:image][:id]).to be_nil
+      end
+    end
+
+    context 'video header' do
+      it 'with id' do
+        flow = build(:flow)
+        flow.add_video_header(media_id: 'VID123')
+
+        header = flow.build_payload[:interactive][:header]
+        expect(header[:type]).to eq('video')
+        expect(header[:video][:id]).to eq('VID123')
+        expect(header[:video][:link]).to be_nil
+      end
+
+      it 'with link' do
+        flow = build(:flow)
+        link = 'https://example.com/vid.mp4'
+        flow.add_video_header(link:)
+
+        header = flow.build_payload[:interactive][:header]
+        expect(header[:type]).to eq('video')
+        expect(header[:video][:link]).to eq(link)
+        expect(header[:video][:id]).to be_nil
+      end
+    end
+
+    context 'document header' do
+      it 'with id' do
+        flow = build(:flow)
+        flow.add_document_header(media_id: 'DOC999')
+
+        header = flow.build_payload[:interactive][:header]
+        expect(header[:type]).to eq('document')
+        expect(header[:document][:id]).to eq('DOC999')
+        expect(header[:document][:link]).to be_nil
+      end
+
+      it 'with link (requires filename)' do
+        flow = build(:flow)
+        link = 'https://example.com/contract.pdf'
+        flow.add_document_header(link:, filename: 'contract.pdf')
+
+        header = flow.build_payload[:interactive][:header]
+        expect(header[:type]).to eq('document')
+        expect(header[:document][:link]).to eq(link)
+        expect(header[:document][:filename]).to eq('contract.pdf')
+        expect(header[:document][:id]).to be_nil
+      end
+    end
+
+    context 'factory :with_header (random type)' do
+      it 'includes a valid header in payload regardless of sampled type' do
+        flow = build(:flow, :with_header)
+        header = flow.build_payload[:interactive][:header]
+
+        expect(header).to be_a(Hash)
+        expect(%w[text image video document]).to include(header[:type])
+
+        case header[:type]
+        when 'text'
+          expect(header[:text]).to be_a(String)
+        when 'image'
+          expect(header[:image][:id]).to be_a(String).or be_nil
+          expect(header[:image][:link]).to be_a(String).or be_nil
+          expect([header[:image][:id], header[:image][:link]].compact).not_to be_empty
+        when 'video'
+          expect(header[:video][:id]).to be_a(String).or be_nil
+          expect(header[:video][:link]).to be_a(String).or be_nil
+          expect([header[:video][:id], header[:video][:link]].compact).not_to be_empty
+        when 'document'
+          expect(header[:document][:id]).to be_a(String).or be_nil
+          expect(header[:document][:link]).to be_a(String).or be_nil
+          expect([header[:document][:id], header[:document][:link]].compact).not_to be_empty
+        end
+      end
+    end
+  end
 end

--- a/spec/warb/resources/flow_spec.rb
+++ b/spec/warb/resources/flow_spec.rb
@@ -65,15 +65,28 @@ RSpec.describe Warb::Resources::Flow do
       end
     end
 
-    context 'dynamic flow' do
-      subject { flow_resource.build_payload }
+    context 'boolean flags' do
+      subject { build(:flow, draft: true, data_exchange: true).build_payload }
 
-      let(:flow_resource) { build :flow, :dynamic }
+      it 'sets mode to draft and action to data_exchange' do
+        params = subject[:interactive][:action][:parameters]
+        expect(params[:mode]).to eq('draft')
+        expect(params[:flow_action]).to eq('data_exchange')
+        expect(params).not_to have_key(:flow_action_payload)
+      end
+    end
 
-      it 'does not include flow_action_payload with screen or data' do
-        payload = subject[:interactive][:action][:parameters]
-        expect(payload[:flow_action]).to eq('data_exchange')
-        expect(payload).not_to have_key(:flow_action_payload)
+    context 'explicit overrides flags' do
+      subject do
+        build(:flow, data_exchange: true, screen: 'FIRST', flow_action: 'navigate',
+              draft: true, mode: 'published').build_payload
+      end
+
+      it 'uses the explicit flow_action and keeps payload with screen' do
+        params = subject[:interactive][:action][:parameters]
+        expect(params[:flow_action]).to eq('navigate')
+        expect(params[:flow_action_payload]).to include(:screen)
+        expect(params[:mode]).to eq('published')
       end
     end
 

--- a/spec/warb/resources/helpers/header_spec.rb
+++ b/spec/warb/resources/helpers/header_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+RSpec.describe Warb::Resources::Helpers::Header do
+  class DummyClass
+    include Warb::Resources::Helpers::Header
+
+    attr_accessor :header
+  end
+
+  subject { DummyClass.new }
+
+  describe '#add_text_header' do
+    it do
+      expect do
+        subject.add_text_header(content: 'John', parameter_name: 'part_of_the_day')
+      end.to change(subject, :header).from(NilClass).to(Warb::Resources::Text)
+    end
+  end
+
+  describe '#add_image_header' do
+    context 'with id, using block' do
+      it do
+        expect do
+          subject.add_image_header(media_id: 'media_id') do |image|
+            expect(image).to be_a Warb::Resources::Image
+            expect(image).to eq subject.header
+          end
+        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Image)
+      end
+    end
+
+    context 'with link, without using block' do
+      it do
+        expect do
+          image = subject.add_image_header(link: 'media_link')
+
+          expect(image).to be_a Warb::Resources::Image
+          expect(image).to eq subject.header
+        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Image)
+      end
+    end
+  end
+
+  describe '#add_document_header' do
+    context 'with id, using block' do
+      it do
+        expect do
+          subject.add_document_header(media_id: 'media_id') do |document|
+            expect(document).to be_a Warb::Resources::Document
+            expect(document).to eq subject.header
+          end
+        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Document)
+      end
+    end
+
+    context 'with link, without using block' do
+      it do
+        expect do
+          document = subject.add_document_header(link: 'media_link')
+
+          expect(document).to be_a Warb::Resources::Document
+          expect(document).to eq subject.header
+        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Document)
+      end
+    end
+  end
+
+  describe '#add_video_header' do
+    context 'with id, using block' do
+      it do
+        expect do
+          subject.add_video_header(media_id: 'media_id') do |video|
+            expect(video).to be_a Warb::Resources::Video
+            expect(video).to eq subject.header
+          end
+        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Video)
+      end
+    end
+
+    context 'with link, without using block' do
+      it do
+        expect do
+          video = subject.add_video_header(link: 'media_link')
+
+          expect(video).to be_a Warb::Resources::Video
+          expect(video).to eq subject.header
+        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Video)
+      end
+    end
+  end
+
+  describe '#add_location_header' do
+    context 'with id, using block' do
+      it do
+        expect do
+          subject.add_location_header do |location|
+            expect(location).to be_a Warb::Resources::Location
+            expect(location).to eq subject.header
+          end
+        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Location)
+      end
+    end
+
+    context 'with link, without using block' do
+      it do
+        expect do
+          location = subject.add_location_header
+
+          expect(location).to be_a Warb::Resources::Location
+          expect(location).to eq subject.header
+        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Location)
+      end
+    end
+  end
+end

--- a/spec/warb/resources/template_spec.rb
+++ b/spec/warb/resources/template_spec.rb
@@ -3,6 +3,10 @@
 RSpec.describe Warb::Resources::Template do
   subject { described_class.new }
 
+  it 'includes Helpers::Header' do
+    expect(described_class).to include(Warb::Resources::Helpers::Header)
+  end
+
   describe '#add_currency_parameter' do
     context 'positional' do
       it do
@@ -100,86 +104,6 @@ RSpec.describe Warb::Resources::Template do
         expect(subject.resources[:text]).to be_a Warb::Resources::Text
 
         expect { subject.add_text_parameter }.to change(subject.resources, :count).by(1)
-      end
-    end
-  end
-
-  describe '#add_text_header' do
-    it do
-      expect do
-        subject.add_text_header(content: 'John', parameter_name: 'part_of_the_day')
-      end.to change(subject, :header).from(NilClass).to(Warb::Resources::Text)
-    end
-  end
-
-  describe '#add_image_header' do
-    context 'with id, using block' do
-      it do
-        expect do
-          subject.add_image_header(media_id: 'media_id') do |image|
-            expect(image).to be_a Warb::Resources::Image
-            expect(image).to eq subject.header
-          end
-        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Image)
-      end
-    end
-
-    context 'with link, without using block' do
-      it do
-        expect do
-          image = subject.add_image_header(link: 'media_link')
-
-          expect(image).to be_a Warb::Resources::Image
-          expect(image).to eq subject.header
-        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Image)
-      end
-    end
-  end
-
-  describe '#add_document_header' do
-    context 'with id, using block' do
-      it do
-        expect do
-          subject.add_document_header(media_id: 'media_id') do |document|
-            expect(document).to be_a Warb::Resources::Document
-            expect(document).to eq subject.header
-          end
-        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Document)
-      end
-    end
-
-    context 'with link, without using block' do
-      it do
-        expect do
-          document = subject.add_document_header(link: 'media_link')
-
-          expect(document).to be_a Warb::Resources::Document
-          expect(document).to eq subject.header
-        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Document)
-      end
-    end
-  end
-
-  describe '#add_video_header' do
-    context 'with id, using block' do
-      it do
-        expect do
-          subject.add_video_header(media_id: 'media_id') do |video|
-            expect(video).to be_a Warb::Resources::Video
-            expect(video).to eq subject.header
-          end
-        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Video)
-      end
-    end
-
-    context 'with link, without using block' do
-      it do
-        expect do
-          video = subject.add_video_header(link: 'media_link')
-
-          expect(video).to be_a Warb::Resources::Video
-          expect(video).to eq subject.header
-        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Video)
       end
     end
   end
@@ -456,30 +380,6 @@ RSpec.describe Warb::Resources::Template do
         expect(buttons.count).to eq 2
         expect(buttons[0]).to match({ type: 'button', index: 0, sub_type: 'voice_call' })
         expect(buttons[1]).to match({ type: 'button', index: 1, sub_type: 'voice_call' })
-      end
-    end
-  end
-
-  describe '#add_location_header' do
-    context 'with id, using block' do
-      it do
-        expect do
-          subject.add_location_header do |location|
-            expect(location).to be_a Warb::Resources::Location
-            expect(location).to eq subject.header
-          end
-        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Location)
-      end
-    end
-
-    context 'with link, without using block' do
-      it do
-        expect do
-          location = subject.add_location_header
-
-          expect(location).to be_a Warb::Resources::Location
-          expect(location).to eq subject.header
-        end.to change(subject, :header).from(NilClass).to(Warb::Resources::Location)
       end
     end
   end


### PR DESCRIPTION
## O que mudou?

Implementamos o suporte para **WhatsApp Flows** , permitindo o envio de mensagens interativas do tipo **flow** diretamente pela gem.  

Antes:
- A gem só suportava **draft flows estáticos** com `flow_action = "navigate"`.
- Qualquer personalização (como mudar para `data_exchange`, published mode ou adicionar header/footer) precisava ser feita na aplicação que chamava a gem.
 
Agora:

- A gem suporta todos os cenários:
- `flow_action` = `"navigate"` (estático) ou `"data_exchange"` (dinâmico).    
- `mode` = `"draft"` ou `"published"`.
- Suporte a `header` (text, image, video, document), `footer`, `body`, `flow_cta`, `flow_token` e dados de prefill (`data`).
- A construção do payload segue 100% o padrão, centralizado dentro de `Resources::Flow`.
- Validações garantem consistência antes de enviar para a API:
    - `flow_id` obrigatório.
    - `body` obrigatório.
    - `screen` obrigatório apenas quando `flow_action = "navigate"`.

## Como funciona
### Antes

Só era possível draft + navigate :
`Warb.flow.dispatch(recipient, flow_id: "0000000000000000", screen: "INITIAL")`

### Agora

##### Static Draft
```ruby
Warb.flow.dispatch(recipient, flow_id: "0000000000000000", mode: "draft", screen: "INITIAL", body: "Open flow")
```

##### Dynamic Draft
```ruby
Warb.flow.dispatch(recipient, flow_id: "0000000000000000", mode: "draft", flow_action: "data_exchange", body: "Fill the form")
```

##### Published Dynamic com headers e CTA
```ruby
Warb.flow.dispatch(recipient) do |flow|
  flow.flow_id     = "1262029882260608"
  flow.flow_action = "data_exchange"
  flow.body        = "Please sign the document"
  flow.flow_cta    = "Sign"

  flow.header = { type: "document", document: { link: "https://example.com/file.pdf", filename: "file.pdf" } }
  flow.footer = "Reply if you need help"
end
```

## Funcionalidades Habilitadas
- os payloads agora saem formatados exatamente como a API espera.
- **Cenários completos**: estático/dinâmico, draft/published, com/sem prefill, headers e footers.
- **Validações internas**: evita erros comuns antes do request.
- **Flexibilidade de uso**: tanto por parâmetros diretos (`dispatch(recipient, ...)`) quanto por construção em bloco (`dispatch do |flow| ... end`).

---

## Testes

- Criada factory `flow` com traits para diferentes cenários (`:dynamic`, `:with_initial_data`, `:with_header`, `:complete_structure`).
- Testes cobrindo:
    - Payload mínimo válido.
    - Payload dinâmico sem `screen`.
    - Payload com headers variados (text, image, video, document).
    - Validação de erros (`flow_id`, `body`, `screen`).
    - Precedência de atributos (`ivars > params hash > defaults`)
