### PR TITLE
Feat: Phone numbers healthcheck

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    warb (0.1.3)
+    warb (0.1.4)
       faraday (~> 2.13)
       faraday-multipart (~> 1.1)
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -44,3 +44,47 @@ end
 ```
 
 Also, note that calling `Warb.setup` multiple times **WILL NOT** override the previous configuration, so you can use it to change the global configuration at any time.
+
+## Phone numbers (quality monitoring)
+
+You can fetch all phone numbers attached to your WhatsApp Business Account (WABA) and their quality/operational signals.
+
+Requirements: make sure you have configured a business_id in your global setup (this method uses the business context, not the sender/phone context).
+```ruby
+Warb.setup do |config|
+  config.access_token = "ACCESS_TOKEN"
+  config.business_id  = "BUSINESS_ID"      # <-- required here
+  config.sender_id    = "SENDER_ID"    # still used for message dispatch
+end
+```
+
+#### Global usage
+```ruby
+phones = Warb.list_phone_numbers
+```
+
+#### Sample response (unwrapped data array):
+```ruby
+=> [
+  {
+    "verified_name"            => "Test",
+    "code_verification_status" => "NOT_VERIFIED",
+    "display_phone_number"     => "00000000000",
+    "quality_rating"           => "GREEN",
+    "platform_type"            => "CLOUD_API",
+    "throughput"               => { "level" => "STANDARD" },
+    "webhook_configuration"    => { "application" => "https://example.com/" },
+    "id"                       => "(phone_number_id)"
+  }
+]
+```
+
+#### Notes
+
+This method returns the data array directly. If you need paging cursors, call the raw client:
+```ruby
+raw = Warb.client.get("phone_numbers", {}, endpoint_prefix: :business_id)
+raw.body # => { "data" => [...], "paging" => { "cursors" => {...} } }
+```
+
+Non-2xx responses raise Warb::RequestError (or subclasses), so you can rescue them in your app.

--- a/lib/warb.rb
+++ b/lib/warb.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'byebug'
 
 require 'faraday'
 require 'faraday/multipart'
@@ -84,6 +85,10 @@ module Warb
       yield(configuration)
 
       client
+    end
+
+    def list_phone_numbers
+      client.get('phone_numbers', endpoint_prefix: :business_id).body['data']
     end
   end
 end

--- a/lib/warb.rb
+++ b/lib/warb.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'byebug'
 
 require 'faraday'
 require 'faraday/multipart'

--- a/lib/warb/resources/flow.rb
+++ b/lib/warb/resources/flow.rb
@@ -72,12 +72,14 @@ module Warb
       def final_action
         explicit = raw_value(:flow_action)
         return explicit.to_s unless blank?(explicit)
+
         resolve(:data_exchange) ? 'data_exchange' : 'navigate'
       end
 
       def final_mode
         explicit = raw_value(:mode)
         return explicit.to_s unless blank?(explicit)
+
         resolve(:draft) ? 'draft' : 'published'
       end
 
@@ -86,8 +88,8 @@ module Warb
         validates :body,    required: true
 
         validates :screen,
-                 required: -> { final_action == 'navigate' },
-                 message:  'screen is required for flow_action=navigate'
+                  required: -> { final_action == 'navigate' },
+                  message: 'screen is required for flow_action=navigate'
       end
     end
   end

--- a/lib/warb/version.rb
+++ b/lib/warb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Warb
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/spec/warb/resources/flow_spec.rb
+++ b/spec/warb/resources/flow_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Warb::Resources::Flow do
     context 'explicit overrides flags' do
       subject do
         build(:flow, data_exchange: true, screen: 'FIRST', flow_action: 'navigate',
-              draft: true, mode: 'published').build_payload
+                     draft: true, mode: 'published').build_payload
       end
 
       it 'uses the explicit flow_action and keeps payload with screen' do

--- a/spec/warb/resources/template_spec.rb
+++ b/spec/warb/resources/template_spec.rb
@@ -591,31 +591,31 @@ RSpec.describe Warb::Resources::Template do
     end
   end
 
-  describe "#build_creation_payload" do
-    context "with positional parameters" do
+  describe '#build_creation_payload' do
+    context 'with positional parameters' do
       before do
         allow(subject).to receive_messages(
-          name: "template_name",
+          name: 'template_name',
           language: Warb::Language::ENGLISH_US,
           category: Warb::Category::UTILITY,
-          body: Warb::Resources::Text.new(content: "Hello, {{1}}", examples: ["John"])
+          body: Warb::Resources::Text.new(content: 'Hello, {{1}}', examples: ['John'])
         )
       end
 
       it do
         expect(subject.creation_payload).to eq(
           {
-            name: "template_name",
-            language: "en_US",
-            category: "UTILITY",
+            name: 'template_name',
+            language: 'en_US',
+            category: 'UTILITY',
             components: [
               {
-                type: "body",
-                text: "Hello, {{1}}",
+                type: 'body',
+                text: 'Hello, {{1}}',
                 example: {
                   body_text: [
                     [
-                      "John"
+                      'John'
                     ]
                   ]
                 }

--- a/spec/warb_spec.rb
+++ b/spec/warb_spec.rb
@@ -95,4 +95,28 @@ RSpec.describe Warb do
       end
     end
   end
+
+  describe '.list_phone_numbers' do
+    let(:client)   { instance_double(Warb::Client) }
+    let(:response) { instance_double(Warb::Response, body: { 'data' => [{ 'id' => '375420581369195' }] }) }
+
+    before do
+      allow(described_class).to receive(:client).and_return(client)
+    end
+
+    it 'GET /{business_id}/phone_numbers' do
+      expect(client)
+        .to receive(:get)
+        .with('phone_numbers', endpoint_prefix: :business_id)
+        .and_return(response)
+
+      expect(described_class.list_phone_numbers).to eq([{ 'id' => '375420581369195' }])
+    end
+
+    it 'raise errors' do
+      allow(client).to receive(:get).and_raise(Warb::BadRequest.new('bad'))
+
+      expect { described_class.list_phone_numbers }.to raise_error(Warb::BadRequest)
+    end
+  end
 end


### PR DESCRIPTION
Adicionado o método que faz a verificação de saúde da comunicação dos números de telefone cadastrados além da documentação e testes do método, alterações do rubocop e alteração no arquivo de versões.
